### PR TITLE
Creating a docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,9 @@
 version: '3'
 
 services:
-  mysql_db:
+  mysql:
     image: mysql:5.7
-    container_name: mysql_db
+    container_name: mysql
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: intelligrid

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  mysql_db:
+    image: mysql:5.7
+    container_name: mysql_db
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: intelligrid
+      MYSQL_USER: app
+      MYSQL_PASSWORD: 123456
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./mysql:/var/lib/mysql


### PR DESCRIPTION
Criando o docker-compose para facilitar o desenvolvimento local.
Nele contem o as configurações necessárias para subir um mysql local.